### PR TITLE
Add missing Window methods to C API

### DIFF
--- a/include/AppCore/CAPI.h
+++ b/include/AppCore/CAPI.h
@@ -282,6 +282,12 @@ ACExport bool ulWindowIsFullscreen(ULWindow window);
 ACExport bool ulWindowIsAccelerated(ULWindow window);
 
 ///
+/// The render buffer id of the window's backing texture.
+/// (This will be 0 if the window is not accelerated).
+/// 
+ACExport unsigned int ulWindowGetRenderBufferId(ULWindow window);
+
+///
 /// Get the DPI scale of a window.
 ///
 ACExport double ulWindowGetScale(ULWindow window);

--- a/include/AppCore/CAPI.h
+++ b/include/AppCore/CAPI.h
@@ -277,6 +277,11 @@ ACExport int ulWindowGetPositionY(ULWindow window);
 ACExport bool ulWindowIsFullscreen(ULWindow window);
 
 ///
+/// Whether or not the window is GPU accelerated.
+/// 
+ACExport bool ulWindowIsAccelerated(ULWindow window);
+
+///
 /// Get the DPI scale of a window.
 ///
 ACExport double ulWindowGetScale(ULWindow window);

--- a/include/AppCore/Window.h
+++ b/include/AppCore/Window.h
@@ -150,7 +150,7 @@ public:
   virtual bool is_accelerated() const = 0;
 
   ///
-  /// The render buffer id of the the window's backing texture.
+  /// The render buffer id of the window's backing texture.
   /// (This will be 0 if the window is not accelerated).
   /// 
   virtual uint32_t render_buffer_id() const = 0;

--- a/src/common/CAPI.cpp
+++ b/src/common/CAPI.cpp
@@ -209,6 +209,10 @@ bool ulWindowIsAccelerated(ULWindow window) {
   return window->val->is_accelerated();
 }
 
+unsigned int ulWindowGetRenderBufferId(ULWindow window) {
+  return window->val->render_buffer_id();
+}
+
 double ulWindowGetScale(ULWindow window) {
   return window->val->scale();
 }

--- a/src/common/CAPI.cpp
+++ b/src/common/CAPI.cpp
@@ -205,6 +205,10 @@ bool ulWindowIsFullscreen(ULWindow window) {
   return window->val->is_fullscreen();
 }
 
+bool ulWindowIsAccelerated(ULWindow window) {
+  return window->val->is_accelerated();
+}
+
 double ulWindowGetScale(ULWindow window) {
   return window->val->scale();
 }


### PR DESCRIPTION
`Window::is_accelerated()` and `Window::render_buffer_id()` methods were missing in the C API, I've added them with the functions `ulWindowIsAccelerated()` and `ulWindowGetRenderBufferId()`.