### PR TITLE
Lock clipboard before emptying it

### DIFF
--- a/src/win/ClipboardWin.cpp
+++ b/src/win/ClipboardWin.cpp
@@ -4,7 +4,10 @@
 namespace ultralight {
 
 void ClipboardWin::Clear() {
+  if (!OpenClipboard(0))
+    return;
   EmptyClipboard();
+  CloseClipboard();
 }
 
 String ClipboardWin::ReadPlainText() {


### PR DESCRIPTION
According to remark about EmptyDialog(), an application must open the clipboard before emptying it by using the OpenClipboard function. If the application specifies a NULL window handle when opening the clipboard, EmptyClipboard succeeds but sets the clipboard owner to NULL. This can cause SetClipboardData to fail.
https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-emptyclipboard